### PR TITLE
use cluster.open-cluster-management.io/backup-pvc-hook label to wait before running the snapshot

### DIFF
--- a/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -119,6 +119,17 @@ spec:
                 {{- end }}
                         RESTIC_REPOSITORY: {{ ( ( (cat $common_restic_repo "/" $pvc.metadata.namespace "-" $pvc.metadata.name ) | replace " " "" ) | base64enc ) }}                      
                       type: Opaque
+
+                  {{- /* Look for the PVC label used to run a manual snapshot when waiting for the PVC to prepare for backup - ie db freeze */ -}}
+                  {{- /* Don't create the ReplicationSource if the label is not set yet, this is the initial step */ -}}
+                  {{- $wait_for_hooks_pvc_label := "cluster.open-cluster-management.io/backup-pvc-hook" }}
+                  {{- $wait_for_hooks_pvc_value := "undefined" }}
+                  {{- range $pvc_with_hooks := (lookup "v1" "PersistentVolumeClaim" $pvc.metadata.namespace "" $wait_for_hooks_pvc_label).items }}
+                    {{ if eq $pvc_with_hooks.metadata.name  $pvc.metadata.name}}
+                      {{- $wait_for_hooks_pvc_value = (index $pvc.metadata.labels $wait_for_hooks_pvc_label) }}                 
+                    {{- end }}
+                  {{- end }} 
+                  {{ if not ( eq $wait_for_hooks_pvc_value "" ) }}
                   - complianceType: musthave
                     objectDefinition:
                       kind: ReplicationSource
@@ -140,7 +151,14 @@ spec:
                             monthly: '{{ fromConfigMap $ns $volsync_map "retain_monthly" | toInt }}'
                         sourcePVC: {{ $pvc.metadata.name }}
                         trigger:
-                          schedule: '{{ fromConfigMap $ns $volsync_map "trigger_schedule" }}'
+                          {{ if eq $wait_for_hooks_pvc_value "undefined" }} 
+                          {{- /* if the cluster.open-cluster-management.io/backup-pvc-hook hook label was not set, run this using a schedule */ -}} 
+                          schedule: '{{ fromConfigMap $ns $volsync_map "trigger_schedule" }}'  
+                          {{- else }}
+                          {{- /* if the cluster.open-cluster-management.io/backup-pvc-hook hook label was set, run manual */ -}}                                       
+                          manual: '{{ index $pvc.metadata.labels $wait_for_hooks_pvc_label }}' 
+                          {{- end }}   
+                  {{- end }}
                 {{- end }}        
               {{- end }}
                  {{ if not (eq $volsync_pvcs_str "") }}


### PR DESCRIPTION
Use cluster.open-cluster-management.io/backup-pvc-hook on PVC to ask the policy to run source replication manually

- If cluster.open-cluster-management.io/backup-pvc-hook = '' , the ReplicationSource is not created
- If cluster.open-cluster-management.io/backup-pvc-hook is not empty , the ReplicationSource is not created
- whenever the value of the cluster.open-cluster-management.io/backup-pvc-hook changes, the ReplicationSource trigger.manual value is updated


Sample PVC:

1. Initial step ( ReplicationSource not created )

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: mongo-storage
  namespace: pacman-ns
  labels:
    cluster.open-cluster-management.io/backup-pvc-hook:''
    cluster.open-cluster-management.io/volsync: acm
```

2. When db is ready for a snapshot ( after freeze )

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: mongo-storage
  namespace: pacman-ns
  labels:
    cluster.open-cluster-management.io/backup-pvc-hook:'run1'
    cluster.open-cluster-management.io/volsync: acm
```

This is going to create the RS

```
apiVersion: volsync.backube/v1alpha1
kind: ReplicationSource
metadata:
  labels:
    cluster.open-cluster-management.io/volsync: acm
  name: mongo-storage
  namespace: pacman-ns
spec:
  restic:
    cacheCapacity: 2Gi
    copyMethod: Snapshot
    pruneIntervalDays: 2
    repository: mongo-storage-restic-secret-vb
    retain:
      daily: 2
      hourly: 3
      monthly: 1
  sourcePVC: mongo-storage
  trigger:
    manual: run1
status:
  conditions:
    - lastTransitionTime: '2024-01-24T23:28:42Z'
      message: Waiting for manual trigger
      reason: WaitingForManual
      status: 'False'
      type: Synchronizing
  lastManualSync: run
  lastSyncDuration: 57.37987187s
  lastSyncTime: '2024-01-24T23:28:42Z'
  latestMoverStatus:
    logs: |-
      using parent snapshot ec3fa534
      Added to the repository: 1.582 MiB (978.346 KiB stored)
      processed 44 files, 346.548 MiB in 0:01
      snapshot f9d45065 saved
      Restic completed in 5s
    result: Successful
  restic: {}
```

- You need to unlock the db once the RS is successful - I didn't cover this for now

3. When another snapshot is required , update on the PVC the cluster.open-cluster-management.io/backup-pvc-hook value. 

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: mongo-storage
  namespace: pacman-ns
  labels:
    cluster.open-cluster-management.io/backup-pvc-hook:'run2'
    cluster.open-cluster-management.io/volsync: acm
```

The policy will trigger an update on the RS trigger.manual so a new snapshot is run:

```
apiVersion: volsync.backube/v1alpha1
kind: ReplicationSource
metadata:
  labels:
    cluster.open-cluster-management.io/volsync: acm
  name: mongo-storage
  namespace: pacman-ns
spec:
  restic:
    cacheCapacity: 2Gi
    copyMethod: Snapshot
    pruneIntervalDays: 2
    repository: mongo-storage-restic-secret-vb
    retain:
      daily: 2
      hourly: 3
      monthly: 1
  sourcePVC: mongo-storage
  trigger:
    manual: run2
```