### PR TITLE
add cluster.open-cluster-management.io/last-backup-schedule label on PVC

### DIFF
--- a/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -37,6 +37,22 @@ spec:
 
             {{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}
             {{ if $volsync_backup_cond }}
+
+              {{- /* The backup-schedule-hook label will be updated with the latest credentials backup execution timestamp */ -}}
+              {{- /* The backup-schedule-hook can be used by the PVC owner to know when to require a new snapshot - ask for one whenever the oadp backup is running */ -}}
+              {{- $wait_for_schedule_hooks_pvc_label := "cluster.open-cluster-management.io/last-backup-schedule" }}
+              {{- $wait_for_schedule_hooks_pvc_value := "" }}
+              {{- $credentials_name := "acm-credentials-schedule" }}
+              {{- $credentials_schedule := lookup $velero_api $kind_schedule $ns $credentials_name }}
+              {{ if and (eq $credentials_schedule.metadata.name $credentials_name) (eq $credentials_schedule.status.phase "Enabled") }}
+                {{- /* If credentials schedule exists and is enabled, take the timestamp from the latest backup */ -}}
+                {{- /* The backup is created on the schedule creation, even if the job schedule is not triggered; so use the schedule creation timestamp initially */ -}}
+                {{- $wait_for_schedule_hooks_pvc_value = $credentials_schedule.metadata.creationTimestamp }}
+                {{ if not (eq "" $credentials_schedule.status.lastBackup )}}
+                  {{- $wait_for_schedule_hooks_pvc_value = $credentials_schedule.status.lastBackup }}
+                {{- end }}
+              {{- end }}
+
               {{- range $rs := (lookup "volsync.backube/v1alpha1" "ReplicationSource" "" "" $volsync_label).items }}
                 {{- $pvc_rs := (lookup "v1" "PersistentVolumeClaim" $rs.metadata.namespace "" $volsync_label).items }}
                 {{- /* If the PVC in the ReplicationSource ns no longer exists or doesn't have the volsync label, delete the ReplicationSource */ -}}
@@ -126,7 +142,16 @@ spec:
                   {{- $wait_for_hooks_pvc_value := "undefined" }}
                   {{- range $pvc_with_hooks := (lookup "v1" "PersistentVolumeClaim" $pvc.metadata.namespace "" $wait_for_hooks_pvc_label).items }}
                     {{ if eq $pvc_with_hooks.metadata.name  $pvc.metadata.name}}
-                      {{- $wait_for_hooks_pvc_value = (index $pvc.metadata.labels $wait_for_hooks_pvc_label) }}                 
+                      {{- $wait_for_hooks_pvc_value = (index $pvc.metadata.labels $wait_for_hooks_pvc_label) }}
+                  - complianceType: musthave
+                    objectDefinition:
+                      kind: PersistentVolumeClaim
+                      apiVersion: v1
+                      metadata:
+                        name: {{ $pvc.metadata.name }}
+                        namespace: {{ $pvc.metadata.namespace }}
+                        labels:
+                          {{ $wait_for_schedule_hooks_pvc_label }}: {{ $wait_for_schedule_hooks_pvc_value | replace ":" "." }}            
                     {{- end }}
                   {{- end }} 
                   {{ if not ( eq $wait_for_hooks_pvc_value "" ) }}


### PR DESCRIPTION
add `cluster.open-cluster-management.io/last-backup-schedule` label on PVC to match the timestamp of the last hub backup schedule


```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: mongo-storage
  namespace: pacman-ns
  labels:
    cluster.open-cluster-management.io/backup-pvc-hook: ''
    cluster.open-cluster-management.io/last-backup-schedule: 2024-01-25T22.00.15Z
    cluster.open-cluster-management.io/volsync: ''
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 8Gi
  volumeName: pvc-54d09ed2-df37-4f38-9e98-e0bdcbf8a4e1
  storageClassName: gp3-csi
  volumeMode: Filesystem
status:
  phase: Bound
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 8Gi
```

This can be used by the PVC owner to know when to ask for a new manual run for the volsync ReplicationSource

It is to be used in conjunction with the `cluster.open-cluster-management.io/backup-pvc-hook` label

Scenario:
- PVC user sets the `cluster.open-cluster-management.io/backup-pvc-hook:''` label, to be used to initiate manual snapshots
- if the cluster.open-cluster-management.io/backup-pvc-hook is set, policy sets the `cluster.open-cluster-management.io/last-backup-schedule: 2024-01-25T22.00.15Z` to match the timestamp of the latest hub backup ( using the hub backup schedule ). The policy updates the label value every time a new hub backup is executed. The PVC owner can watch this label and request a new manual snapshot if the value changes. In this way, a new snapshot is requested every time a hub backup is called by the hub backup schedule ( or course you can chose to skip the manual snapshot if the hub backup runs too often; it's up to the PVC owner to decide whether to do a run or wait for the next schedule: let's say the hub backup run evefry 1h but you want your pvc to be backed every 2h, you skip one label update )



Note that the timestamp format on the label has : replaced with . ( 2024-01-25T22:00:15Z had become 2024-01-25T22.00.15Z). : are not valid chars in a label value

`cluster.open-cluster-management.io/last-backup-schedule: 2024-01-25T22.00.15Z`


