### PR TITLE
add labels to PVC setting last sync info

### DIFF
--- a/acm-volsync-hub-backup/README.md
+++ b/acm-volsync-hub-backup/README.md
@@ -252,7 +252,7 @@ ACM user, on Restore hub:
   - The user manually installs the policy from the community project
 6. Creates an ACM Restore resource and restores active data
   - The policy creates the volsync `ReplicationDestination` for all PVCs defined in the restored volsync-config-pvcs ConfigMap
-  - the app using the PVC must be restored after the PVC is created 
+  - the app using the PVC must be restored after the PVC is created so make sure these resources are restored at cluster activation time.  
 
 ## References
 - [Volsync](https://access.redhat.com/login?redirectTo=https%3A%2F%2Faccess.redhat.com%2Fdocumentation%2Fen-us%2Fred_hat_advanced_cluster_management_for_kubernetes%2F2.8%2Fhtml%2Fbusiness_continuity%2Fbusiness-cont-overview%23restic-backup-volsync)

--- a/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
+++ b/acm-volsync-hub-backup/acm-volsync-cr-source.yaml
@@ -35,21 +35,26 @@ spec:
             {{- $volsync_backup_cond := gt (len ( lookup $velero_api $kind_schedule $ns "" $schedule_label).items ) 0  }}
             {{- $volsync_pvcs := "volsync-config-pvcs" }}
 
+            {{- /* PVC labels  */ -}}
+            {{- $last_backup_schedule_label := "cluster.open-cluster-management.io/backup-last-schedule" }}
+            {{- $last_sync_name_label := "cluster.open-cluster-management.io/backup-last-sync-name" }}
+            {{- $last_sync_time_label := "cluster.open-cluster-management.io/backup-last-sync-time" }}
+            {{- $last_sync_status_label := "cluster.open-cluster-management.io/backup-last-sync-status" }}
+
             {{- /* Create the volsync ReplicationSource and secret - if BackupSchedule exists ; delete ReplicationSource otherwise */ -}}
             {{ if $volsync_backup_cond }}
 
               {{- /* The backup-schedule-hook label will be updated with the latest credentials backup execution timestamp */ -}}
               {{- /* The backup-schedule-hook can be used by the PVC owner to know when to require a new snapshot - ask for one whenever the oadp backup is running */ -}}
-              {{- $wait_for_schedule_hooks_pvc_label := "cluster.open-cluster-management.io/last-backup-schedule" }}
-              {{- $wait_for_schedule_hooks_pvc_value := "" }}
+              {{- $last_backup_schedule_value := "" }}
               {{- $credentials_name := "acm-credentials-schedule" }}
               {{- $credentials_schedule := lookup $velero_api $kind_schedule $ns $credentials_name }}
               {{ if and (eq $credentials_schedule.metadata.name $credentials_name) (eq $credentials_schedule.status.phase "Enabled") }}
                 {{- /* If credentials schedule exists and is enabled, take the timestamp from the latest backup */ -}}
                 {{- /* The backup is created on the schedule creation, even if the job schedule is not triggered; so use the schedule creation timestamp initially */ -}}
-                {{- $wait_for_schedule_hooks_pvc_value = $credentials_schedule.metadata.creationTimestamp }}
+                {{- $last_backup_schedule_value = $credentials_schedule.metadata.creationTimestamp }}
                 {{ if not (eq "" $credentials_schedule.status.lastBackup )}}
-                  {{- $wait_for_schedule_hooks_pvc_value = $credentials_schedule.status.lastBackup }}
+                  {{- $last_backup_schedule_value = $credentials_schedule.status.lastBackup }}
                 {{- end }}
               {{- end }}
 
@@ -151,7 +156,15 @@ spec:
                         name: {{ $pvc.metadata.name }}
                         namespace: {{ $pvc.metadata.namespace }}
                         labels:
-                          {{ $wait_for_schedule_hooks_pvc_label }}: {{ $wait_for_schedule_hooks_pvc_value | replace ":" "." }}            
+                          {{- /* Get the ReplicationSource status and add it to the PVC; used by the PVC owner to decide when to run a unlock of data */ -}}
+                          {{- $replicationSource :=  lookup "volsync.backube/v1alpha1" "ReplicationSource" $pvc.metadata.namespace $pvc.metadata.name }}
+                          {{ if eq $replicationSource.metadata.name $pvc.metadata.name}}
+                          {{- /* If the ReplicationSource with the PVC name was found in the PVC ns, set the labels on PVC */ -}}
+                          {{ $last_sync_name_label }}: {{ $replicationSource.status.lastManualSync }}
+                          {{ $last_sync_time_label }}: {{ $replicationSource.status.lastSyncTime | replace ":" "." }}
+                          {{ $last_sync_status_label }}: {{ $replicationSource.status.latestMoverStatus.result }}
+                          {{- end }}
+                          {{ $last_backup_schedule_label }}: {{ $last_backup_schedule_value | replace ":" "." }}            
                     {{- end }}
                   {{- end }} 
                   {{ if not ( eq $wait_for_hooks_pvc_value "" ) }}

--- a/acm-volsync-hub-backup/samples/storage-mapping.yml
+++ b/acm-volsync-hub-backup/samples/storage-mapping.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # any name can be used
+  name: change-storage-class-config
+  # must be in the velero namespace
+  namespace: open-cluster-management-backup
+  # the below labels should be used verbatim in your
+  # ConfigMap.
+  labels:
+    velero.io/change-storage-class: RestoreItemAction
+data:
+  # add 1+ key-value pairs here, where the key is the old
+  # storage class name and the value is the new storage
+  # class name.
+  local-disks: openebs-cstor-r3

--- a/acm-volsync-hub-backup/samples/volsync-config.yaml
+++ b/acm-volsync-hub-backup/samples/volsync-config.yaml
@@ -1,0 +1,16 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volsync-config
+  namespace: open-cluster-management-backup
+  labels:
+    cluster.open-cluster-management.io/backup: cluster-activation
+data:
+  cacheCapacity: 2Gi
+  copyMethod: Snapshot
+  pruneIntervalDays: '2'
+  repository: restic-secret-vb
+  retain_daily: '2'
+  retain_hourly: '3'
+  retain_monthly: '1'
+  trigger_schedule: 0 */1 * * *


### PR DESCRIPTION
Changes:

Introduced the following labels on PVC 

            {{- $last_sync_name_label := "cluster.open-cluster-management.io/backup-last-sync-name" }}
            {{- $last_sync_time_label := "cluster.open-cluster-management.io/backup-last-sync-time" }}
            {{- $last_sync_status_label := "cluster.open-cluster-management.io/backup-last-sync-status" }}

Example:

```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: mongo-storage
  namespace: pacman-ns
  labels:
    cluster.open-cluster-management.io/volsync: ''
    cluster.open-cluster-management.io/backup-pvc-hook: 'run1'  # PVC owner updates the label with the new manual run name
    cluster.open-cluster-management.io/backup-last-schedule: 2024-01-26T18.00.53Z # policy sets the time of the last hub schedule 
    cluster.open-cluster-management.io/backup-last-sync-name: run1 # policy sets the name of the last manual sync name
    cluster.open-cluster-management.io/backup-last-sync-time: 2024-01-25T18.57.30Z # policy sets the time of the last manual sync
    cluster.open-cluster-management.io/backup-last-sync-status: Successful # policy sets the status of the last manual sync
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 8Gi
  volumeName: pvc-54d09ed2-df37-4f38-9e98-e0bdcbf8a4e1
  storageClassName: gp3-csi
  volumeMode: Filesystem
status:
  phase: Bound
  accessModes:
    - ReadWriteOnce
  capacity:
    storage: 8Gi
```

Scenario:

1. PVC owner  checks the `cluster.open-cluster-management.io/backup-last-schedule` and noticed that a new hub scheduled backup was executed. Owner wants to run a PVC snapshost too 
2. Owner sets cluster.open-cluster-management.io/backup-pvc-hook: 'run2' 
3. Policy updates the ReplicationSource
```
  trigger:
    manual: run2
```
4. A new snapshot runs. Policy updates PVC labels using the ReplicationSource status
```
    cluster.open-cluster-management.io/backup-last-sync-name: run1 << still old value, this sync not done yet
    cluster.open-cluster-management.io/backup-last-sync-time: 2024-01-26T19.04.23Z
    cluster.open-cluster-management.io/backup-last-sync-status: Successful << old status, sync still in process 
    cluster.open-cluster-management.io/backup-pvc-hook: run2 << new sync 
```
Eventually
```
    cluster.open-cluster-management.io/backup-last-sync-name: run2 << new value
    cluster.open-cluster-management.io/backup-last-sync-time: 2024-01-26T19.04.23Z
    cluster.open-cluster-management.io/backup-last-sync-status: Successful << new status, bc backup-last-sync-name: run2
    cluster.open-cluster-management.io/backup-pvc-hook: run2 << new sync 
```

